### PR TITLE
Fix vulnerability warning from npm audit for lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -750,9 +750,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "log-symbols": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/Aplo/saml2js/issues"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.20",
     "xmldom": "^0.1.16",
     "xpath": "0.0.5"
   },


### PR DESCRIPTION
Fixes vulnerability warning for lodash

                       === npm audit security report ===                        
                                                                                
  High            Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   lodash                                                        
                                                                                
  Path            lodash                                                        
                                                                                
  More info       https://npmjs.com/advisories/1065                             
                                                                                


                                                                                
  Low             Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   lodash                                                        
                                                                                
  Path            lodash                                                        
                                                                                
  More info       https://npmjs.com/advisories/1523                             
                                                                                

Please release new version as well with changes